### PR TITLE
logout: na conexão ao banco de dados remoto Redis/host 'redis-18070.c…

### DIFF
--- a/redis/jwtBlacklist.js
+++ b/redis/jwtBlacklist.js
@@ -17,7 +17,7 @@ let creatClientOptions = {
 }
 
 if (process.env.REDIS_PASS) { 
-  creatClientOptions.url = `redis://default:${process.env.REDIS_PASS}@${process.env.REDIS_HOST}:${process.env.REDIS_PORT}`;
+  creatClientOptions.url = `redis://${process.env.REDIS_USER}:${process.env.REDIS_PASS}@${process.env.REDIS_HOST}:${process.env.REDIS_PORT}`;
 } else { // localhost
   creatClientOptions.socket = {
     host: process.env.REDIS_HOST,


### PR DESCRIPTION
…61.us-east-1-3.ec2.cloud.redislabs.com', também considerar o username (REDIS_USER) das variáveis de ambiente (arq .env). Anteriormente o username era um valor fixo.